### PR TITLE
Disable apparmor for telegraf

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ computer which is being monitored with telegraf.
     3. Configure Influx HTTP endpoint (http://influxdb:8086 - the grafana
        backend can find this server name via the internal docker network.)
     4. Set Database name `telegraf_metrics`
-    5. Credentials as set in `.env`
+    5. Credentials and your host name as set in `.env`
 5. Setup dashboards
    1. System metrics:
       a. Go to http://localhost:3001/dashboard/import

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     volumes:
     - ./telegraf/etc/telegraf.conf:/etc/telegraf/telegraf.conf:ro
     - /:/hostfs:ro
+    - influx_socket_vol:/var/run/influxdb
     depends_on:
       - influxdb
     links:
@@ -18,6 +19,7 @@ services:
     - HOST_VAR=/hostfs/var
     - HOST_RUN=/hostfs/run
     - HOST_MOUNT_PREFIX=/hostfs
+    env_file: .env
     # Tweak to avoid many apparmor errors
     # https://github.com/influxdata/telegraf/issues/6574
     security_opt:
@@ -29,8 +31,10 @@ services:
     ports:
       - '127.0.0.1:8086:8086'
     volumes:
+      - ./influxdb/etc/influxdb.conf:/etc/influxdb/influxdb.conf:ro
       - ./:/imports
       - influxdb_data:/var/lib/influxdb
+      - influx_socket_vol:/var/run/influxdb
 
   grafana:
     image: grafana/grafana:7.3.5
@@ -49,3 +53,4 @@ services:
 volumes:
   grafana_data: {}
   influxdb_data: {}
+  influx_socket_vol: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,10 @@ services:
     - HOST_VAR=/hostfs/var
     - HOST_RUN=/hostfs/run
     - HOST_MOUNT_PREFIX=/hostfs
+    # Tweak to avoid many apparmor errors
+    # https://github.com/influxdata/telegraf/issues/6574
+    security_opt:
+    - apparmor:unconfined
 
   influxdb:
     image: influxdb:1.8-alpine

--- a/env.example
+++ b/env.example
@@ -6,3 +6,6 @@ GF_INSTALL_PLUGINS=
 INFLUXDB_DB=influx
 INFLUXDB_ADMIN_USER=admin
 INFLUXDB_ADMIN_PASSWORD=admin
+
+# Telegraf node config (set to your dev server name)
+JULIAHUB_HOSTNAME=juliahub_enterprise

--- a/influxdb/etc/influxdb.conf
+++ b/influxdb/etc/influxdb.conf
@@ -1,0 +1,11 @@
+[meta]
+  dir = "/var/lib/influxdb/meta"
+
+[data]
+  dir = "/var/lib/influxdb/data"
+  engine = "tsm1"
+  wal-dir = "/var/lib/influxdb/wal"
+
+[http]
+  unix-socket-enabled = true
+  bind-socket = "/var/run/influxdb/influxdb.sock"

--- a/telegraf/etc/telegraf.conf
+++ b/telegraf/etc/telegraf.conf
@@ -18,7 +18,7 @@
   precision = ""
   debug = false
   quiet = false
-  hostname = ""
+  hostname = "$JULIAHUB_HOSTNAME"
   omit_hostname = false
 
 
@@ -26,7 +26,7 @@
 
 # Configuration for influxdb server to send metrics to
 [[outputs.influxdb]]
-  urls = ["http://influxdb:8086"]
+  urls = ["unix:///var/run/influxdb/influxdb.sock"]
   database = "telegraf_metrics"
 
   ## Retention policy to write to. Empty string writes to the default rp.


### PR DESCRIPTION
Without this, I had the kernel log filling up with many messages like

```
audit: type=1400 audit(1616400910.018:1074): apparmor="DENIED" operation="ptrace" profile="docker-default" pid=2610 comm="telegraf" requested_mask="read" ...
```

logged every 30s or so